### PR TITLE
Review comments

### DIFF
--- a/boards/sw_repo/mailbox_bram/src/mailbox_io.c
+++ b/boards/sw_repo/mailbox_bram/src/mailbox_io.c
@@ -114,8 +114,8 @@ static void volatile_cpy(volatile char* dest, volatile char* src, int len) {
 }
 
 int mailbox_available(int file) {
-	if (file < 0 || file >= MAX_DESCRIPTOR || \
-    descriptors[file].base_addr == NULL) {
+	if (file < 0 || file >= MAX_DESCRIPTOR ||
+			descriptors[file].base_addr == NULL) {
 		errno = EBADF;
 		return -1;
 	}
@@ -141,9 +141,9 @@ int mailbox_available(int file) {
 }
 
 ssize_t mailbox_write(int file, const void* ptr, size_t len) {
-	if (file < 0 || file >= MAX_DESCRIPTOR || \
-    descriptors[file].flags != O_WRONLY || \
-    descriptors[file].base_addr == NULL) {
+	if (file < 0 || file >= MAX_DESCRIPTOR ||
+		    descriptors[file].flags != O_WRONLY ||
+		    descriptors[file].base_addr == NULL) {
 		errno = EBADF;
 		return -1;
 	}
@@ -159,8 +159,8 @@ ssize_t mailbox_write(int file, const void* ptr, size_t len) {
 	}
 	int write_ptr = *ctrl;
 	int to_write = (int)len < available? (int)len : available;
-	int first_block = \
-    to_write < (buf_size - write_ptr)? to_write: buf_size - write_ptr;
+	int first_block = 
+		to_write < (buf_size - write_ptr)? to_write: buf_size - write_ptr;
 	volatile_cpy(buffer + write_ptr, (char*)ptr, first_block);
 	if (first_block < to_write) {
 		volatile_cpy(buffer, (char*)ptr + first_block, to_write - first_block);
@@ -177,9 +177,9 @@ ssize_t mailbox_write(int file, const void* ptr, size_t len) {
 }
 
 ssize_t mailbox_read(int file, void* ptr, size_t len) {
-	if (file < 0 || file >= MAX_DESCRIPTOR || \
-    descriptors[file].flags != O_RDONLY || \
-    descriptors[file].base_addr == NULL) {
+	if (file < 0 || file >= MAX_DESCRIPTOR || 
+			descriptors[file].flags != O_RDONLY || 
+			descriptors[file].base_addr == NULL) {
 		errno = EBADF;
 		return -1;
 	}
@@ -196,8 +196,8 @@ ssize_t mailbox_read(int file, void* ptr, size_t len) {
 	}
 	int read_ptr = *status;
 	int to_read = (int)len < available? (int)len : available;
-	int first_block = \
-    to_read < (buf_size - read_ptr)? to_read: buf_size - read_ptr;
+	int first_block =
+		to_read < (buf_size - read_ptr)? to_read: buf_size - read_ptr;
 	volatile_cpy((char*)ptr, buffer + read_ptr, first_block);
 	if (first_block < to_read) {
 		volatile_cpy((char*)ptr + first_block, buffer, to_read - first_block);

--- a/boards/sw_repo/mailbox_bram/src/mailbox_io.c
+++ b/boards/sw_repo/mailbox_bram/src/mailbox_io.c
@@ -230,17 +230,19 @@ int mailbox_close(int fd) {
 }
 
 
-void mailbox_outbyte(intptr_t device, char c) {
+void mailbox_outbyte(intptr_t device __attribute__((unused)), char c) {
 	mailbox_write(1, &c, 1);
 }
 
-char mailbox_inbyte(intptr_t device) {
+char mailbox_inbyte(intptr_t device __attribute__((unused))) {
 	char c;
 	mailbox_read(0, &c, 1);
 	return c;
 }
 
-off_t mailbox_lseek(int fd, off_t offset, int whence) {
+off_t mailbox_lseek(int fd __attribute__((unused)),
+		off_t offset __attribute__((unused)),
+		int whence __attribute__((unused))) {
 	return ESPIPE;
 }
 
@@ -254,7 +256,9 @@ ssize_t read(int file, void* ptr, size_t len) {
 	return mailbox_read(file, ptr, len);
 }
 
-off_t lseek(int fd, off_t offset, int whence) {
+off_t lseek(int fd __attribute__((unused)),
+		off_t offset __attribute__((unused)),
+		int whence __attribute__((unused))) {
 	return ESPIPE;
 }
 

--- a/boards/sw_repo/pynqmb/src/gpio.c
+++ b/boards/sw_repo/pynqmb/src/gpio.c
@@ -54,67 +54,88 @@
 #ifdef XPAR_XGPIO_NUM_INSTANCES
 #include "xgpio_l.h"
 #include "xgpio.h"
+/* 
+ * GPIO API
+ * Internal GPIO bit format:
+ * 0:0 valid bit
+ * 6:1 low bit
+ * 12:7 high bit
+ * 15:13 channel 1 or channel 2
+ * 31:16 device
+ */
+typedef int gpio;
+typedef union {
+    int fd;
+    struct {
+        int valid: 1, low : 6, high : 6, channel : 3, device : 16;
+    } _gpio;
+} _gpio;
+
+extern XGpio_Config XGpio_ConfigTable[];
 static XGpio xgpio[XPAR_XGPIO_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 gpio gpio_open_device(unsigned int device){
     int status;
     u16 dev_id;
-    gpio mod_id;
+    _gpio gpio_dev;
+    if (device < XPAR_XGPIO_NUM_INSTANCES) {
+        dev_id = (u16)device;
+    } else {
+        int found = 0;
+        for (u16 i = 0; i < XPAR_XGPIO_NUM_INSTANCES; ++i) {
+            if (XGpio_ConfigTable[i].BaseAddress == device) {
+                found = 1;
+                dev_id = i;
+                break;
+            }
+        }
+        if (!found) return -1;
 
-    dev_id = (u16)device;
-#ifdef XPAR_GPIO_0_BASEADDR
-    if (device == XPAR_GPIO_0_BASEADDR){
-        dev_id = 0;
     }
-#endif
-#ifdef XPAR_GPIO_1_BASEADDR
-    if (device == XPAR_GPIO_1_BASEADDR){
-        dev_id = 1;
-    }
-#endif
-
     status = XGpio_Initialize(&xgpio[dev_id], dev_id);
     if (status != XST_SUCCESS) {
-        mod_id.fd = -1;
-        return mod_id;
+        return -1;
     }
 
-    mod_id._gpio.valid = 0;
-    mod_id._gpio.low = GPIO_INDEX_MIN;
-    mod_id._gpio.high = GPIO_INDEX_MAX;
-    mod_id._gpio.channel = 1;
-    mod_id._gpio.device = dev_id;
-    return mod_id;
+    gpio_dev._gpio.valid = 0;
+    gpio_dev._gpio.low = GPIO_INDEX_MIN;
+    gpio_dev._gpio.high = GPIO_INDEX_MAX;
+    gpio_dev._gpio.channel = 1;
+    gpio_dev._gpio.device = dev_id;
+    return gpio_dev.fd;
 }
-
 
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_GPIO_BASEADDR
 #include "xio_switch.h"
-gpio gpio_open(unsigned int pin){
-    init_io_switch();
+gpio gpio_open(unsigned int pin) {
     set_pin(pin, GPIO);
-    return gpio_open_device(XPAR_IO_SWITCH_0_GPIO_BASEADDR);
+    gpio dev = gpio_open_device(XPAR_IO_SWITCH_0_GPIO_BASEADDR);
+    return gpio_configure(dev, pin, pin, 1);
 }
 #endif
 #endif
 
 
-gpio gpio_configure(gpio mod_id, unsigned int low, unsigned int high, 
+gpio gpio_configure(gpio fd, unsigned int low, unsigned int high, 
                     unsigned int channel){
-    mod_id._gpio.low = low;
-    mod_id._gpio.high = high;
-    mod_id._gpio.channel = channel;
-    return mod_id;
+    _gpio gpio_dev;
+    gpio_dev.fd = fd;
+    gpio_dev._gpio.low = low;
+    gpio_dev._gpio.high = high;
+    gpio_dev._gpio.channel = channel;
+    return gpio_dev.fd;
 }
 
 
-void gpio_set_direction(gpio mod_id, unsigned int direction){
+void gpio_set_direction(gpio fd, unsigned int direction){
     unsigned int mask, low, high, channel, dev_id, direction_mask;
-    low = mod_id._gpio.low;
-    high = mod_id._gpio.high;
-    channel = mod_id._gpio.channel;
-    dev_id = mod_id._gpio.device;
+    _gpio gpio_dev;
+    gpio_dev.fd = fd;
+    low = gpio_dev._gpio.low;
+    high = gpio_dev._gpio.high;
+    channel = gpio_dev._gpio.channel;
+    dev_id = gpio_dev._gpio.device;
 
     mask = (0x1 << (high + 1)) - (0x1 << low);
     direction_mask = XGpio_GetDataDirection(&xgpio[dev_id], channel);
@@ -129,12 +150,14 @@ void gpio_set_direction(gpio mod_id, unsigned int direction){
 }
 
 
-int gpio_read(gpio mod_id){
+int gpio_read(gpio fd){
     unsigned int read_value, mask, low, high, channel, dev_id;
-    low = mod_id._gpio.low;
-    high = mod_id._gpio.high;
-    channel = mod_id._gpio.channel;
-    dev_id = mod_id._gpio.device;
+    _gpio gpio_dev;
+    gpio_dev.fd = fd;
+    low = gpio_dev._gpio.low;
+    high = gpio_dev._gpio.high;
+    channel = gpio_dev._gpio.channel;
+    dev_id = gpio_dev._gpio.device;
 
     mask = (0x1 << (high + 1)) - (0x1 << low);
     read_value = XGpio_DiscreteRead(&xgpio[dev_id], channel);
@@ -142,22 +165,26 @@ int gpio_read(gpio mod_id){
 }
 
 
-void gpio_write(gpio mod_id, unsigned int data){
+void gpio_write(gpio fd, unsigned int data){
     unsigned int write_value, mask, low, high, channel, dev_id;
-    low = mod_id._gpio.low;
-    high = mod_id._gpio.high;
-    channel = mod_id._gpio.channel;
-    dev_id = mod_id._gpio.device;
+    _gpio gpio_dev;
+    gpio_dev.fd = fd;
+    low = gpio_dev._gpio.low;
+    high = gpio_dev._gpio.high;
+    channel = gpio_dev._gpio.channel;
+    dev_id = gpio_dev._gpio.device;
 
     write_value = XGpio_DiscreteRead(&xgpio[dev_id], channel);
-    mask = (0x1 << (high + 1)) - (0x1 << low);
+    mask = ~(0x1 << (high + 1)) - (0x1 << low);
     write_value = (write_value & mask) | (data << low);
     XGpio_DiscreteWrite(&xgpio[dev_id], channel, write_value);
 }
 
 
-void gpio_close(gpio mod_id){
+void gpio_close(gpio fd){
     unsigned int mask, low, high, channel, dev_id;
+    _gpio mod_id;
+    mod_id.fd = fd;
     low = mod_id._gpio.low;
     high = mod_id._gpio.high;
     channel = mod_id._gpio.channel;

--- a/boards/sw_repo/pynqmb/src/gpio.c
+++ b/boards/sw_repo/pynqmb/src/gpio.c
@@ -52,6 +52,8 @@
 #include "gpio.h"
 
 #ifdef XPAR_XGPIO_NUM_INSTANCES
+#include "xgpio_l.h"
+#include "xgpio.h"
 static XGpio xgpio[XPAR_XGPIO_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 gpio gpio_open_device(unsigned int device){
@@ -88,6 +90,7 @@ gpio gpio_open_device(unsigned int device){
 
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_GPIO_BASEADDR
+#include "xio_switch.h"
 gpio gpio_open(unsigned int pin){
     init_io_switch();
     set_pin(pin, GPIO);

--- a/boards/sw_repo/pynqmb/src/gpio.h
+++ b/boards/sw_repo/pynqmb/src/gpio.h
@@ -53,13 +53,7 @@
 
 #include <xparameters.h>
 
-#ifdef XPAR_IO_SWITCH_NUM_INSTANCES
-#include "xio_switch.h"
-#endif
-
 #ifdef XPAR_XGPIO_NUM_INSTANCES
-#include "xgpio_l.h"
-#include "xgpio.h"
 
 enum {
 GPIO_OUT = 0,

--- a/boards/sw_repo/pynqmb/src/gpio.h
+++ b/boards/sw_repo/pynqmb/src/gpio.h
@@ -62,31 +62,16 @@ GPIO_INDEX_MIN = 0,
 GPIO_INDEX_MAX = 31,
 };
 
-/* 
- * GPIO API
- * Internal GPIO bit format:
- * 0:0 valid bit
- * 6:1 low bit
- * 12:7 high bit
- * 15:13 channel 1 or channel 2
- * 31:16 device
- */
-typedef int _gpio;
-typedef union {
-    int fd;
-    struct {
-        int valid: 1, low : 6, high : 6, channel : 3, device : 16;
-    } _gpio;
-} gpio;
+typedef int gpio;
 
 gpio gpio_open_device(unsigned int device);
 gpio gpio_open(unsigned int pin);
-gpio gpio_configure(gpio mod_id, unsigned int low, unsigned int high, 
+gpio gpio_configure(gpio fd, unsigned int low, unsigned int high, 
                     unsigned int channel);
-void gpio_set_direction(gpio mod_id, unsigned int direction);
-int gpio_read(gpio mod_id);
-void gpio_write(gpio mod_id, unsigned int data);
-void gpio_close(gpio mod_id);
+void gpio_set_direction(gpio fd, unsigned int direction);
+int gpio_read(gpio fd);
+void gpio_write(gpio fd, unsigned int data);
+void gpio_close(gpio fd);
 unsigned int gpio_get_num_devices(void);
 
 #endif

--- a/boards/sw_repo/pynqmb/src/i2c.c
+++ b/boards/sw_repo/pynqmb/src/i2c.c
@@ -56,23 +56,25 @@
 #include "xiic.h"
 #include "xiic_l.h"
 static XIic xi2c[XPAR_XIIC_NUM_INSTANCES];
+extern XIic_Config XIic_ConfigTable[];
 /************************** Function Definitions ***************************/
 i2c i2c_open_device(unsigned int device){
     int status;
     u16 dev_id;
 
-    dev_id = (u16)device;
-#ifdef XPAR_IIC_0_BASEADDR
-    if (device == XPAR_IIC_0_BASEADDR){
-        dev_id = 0;
+    if (device < XPAR_XIIC_NUM_INSTANCES) {
+        dev_id = (u16)device;
+    } else {
+        int found = 0;
+        for (u16 i = 0; i < XPAR_XIIC_NUM_INSTANCES; ++i) {
+            if (XIic_ConfigTable[i].BaseAddress == device) {
+                found = 1;
+                dev_id = i;
+                break;
+            }
+        }
+        if (!found) return -1;
     }
-#endif
-#ifdef XPAR_IIC_1_BASEADDR
-    if (device == XPAR_IIC_1_BASEADDR){
-        dev_id = 1;
-    }
-#endif
-
     status = XIic_Initialize(&xi2c[dev_id], dev_id);
     if (status != XST_SUCCESS) {
         return -1;

--- a/boards/sw_repo/pynqmb/src/i2c.c
+++ b/boards/sw_repo/pynqmb/src/i2c.c
@@ -53,6 +53,8 @@
 #include "i2c.h"
 
 #ifdef XPAR_XIIC_NUM_INSTANCES
+#include "xiic.h"
+#include "xiic_l.h"
 static XIic xi2c[XPAR_XIIC_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 i2c i2c_open_device(unsigned int device){
@@ -88,6 +90,7 @@ void i2c_read(i2c dev_id, unsigned int slave_address,
 
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_I2C0_BASEADDR
+#include "xio_switch.h"
 i2c i2c_open(unsigned int sda, unsigned int scl){
     init_io_switch();
     set_pin(scl, SCL0);

--- a/boards/sw_repo/pynqmb/src/i2c.c
+++ b/boards/sw_repo/pynqmb/src/i2c.c
@@ -93,8 +93,14 @@ void i2c_read(i2c dev_id, unsigned int slave_address,
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_I2C0_BASEADDR
 #include "xio_switch.h"
+static int last_sda = -1;
+static int last_scl = -1;
+
 i2c i2c_open(unsigned int sda, unsigned int scl){
-    init_io_switch();
+    if (last_sda != -1) set_pin(last_sda, GPIO);
+    if (last_scl != -1) set_pin(last_scl, GPIO);
+    last_sda = sda;
+    last_scl = scl;
     set_pin(scl, SCL0);
     set_pin(sda, SDA0);
     return i2c_open_device(XPAR_IO_SWITCH_0_I2C0_BASEADDR);

--- a/boards/sw_repo/pynqmb/src/i2c.h
+++ b/boards/sw_repo/pynqmb/src/i2c.h
@@ -54,12 +54,7 @@
 
 #include <xparameters.h>
 
-#ifdef XPAR_IO_SWITCH_NUM_INSTANCES
-#include "xio_switch.h"
-#endif
-
 #ifdef XPAR_XIIC_NUM_INSTANCES
-#include "xiic.h"
 
 /* 
  * IIC API

--- a/boards/sw_repo/pynqmb/src/spi.c
+++ b/boards/sw_repo/pynqmb/src/spi.c
@@ -53,6 +53,8 @@
 #include "spi.h"
 
 #ifdef XPAR_XSPI_NUM_INSTANCES
+#include "xspi_l.h"
+#include "xspi.h"
 static XSpi xspi[XPAR_XTMRCTR_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 spi spi_open_device(unsigned int device){
@@ -99,6 +101,7 @@ spi spi_open_device(unsigned int device){
 
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_SPI0_BASEADDR
+#include "xio_switch.h"
 spi spi_open(unsigned int spiclk, unsigned int miso, 
              unsigned int mosi, unsigned int ss){
     init_io_switch();

--- a/boards/sw_repo/pynqmb/src/spi.c
+++ b/boards/sw_repo/pynqmb/src/spi.c
@@ -55,7 +55,7 @@
 #ifdef XPAR_XSPI_NUM_INSTANCES
 #include "xspi_l.h"
 #include "xspi.h"
-static XSpi xspi[XPAR_XTMRCTR_NUM_INSTANCES];
+static XSpi xspi[XPAR_XSPI_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 spi spi_open_device(unsigned int device){
     int status;

--- a/boards/sw_repo/pynqmb/src/spi.c
+++ b/boards/sw_repo/pynqmb/src/spi.c
@@ -56,6 +56,7 @@
 #include "xspi_l.h"
 #include "xspi.h"
 static XSpi xspi[XPAR_XSPI_NUM_INSTANCES];
+extern XSpi_Config XSpi_ConfigTable[];
 /************************** Function Definitions ***************************/
 spi spi_open_device(unsigned int device){
     int status;
@@ -63,18 +64,19 @@ spi spi_open_device(unsigned int device){
     unsigned int base_address;
     u32 control;
     
-    dev_id = (u16)device;
-#ifdef XPAR_SPI_0_BASEADDR
-    if (device == XPAR_SPI_0_BASEADDR){
-        dev_id = 0;
+    if (device < XPAR_XSPI_NUM_INSTANCES) {
+        dev_id = (u16)device;
+    } else {
+        int found = 0;
+        for (u16 i = 0; i < XPAR_XSPI_NUM_INSTANCES; ++i) {
+            if (XSpi_ConfigTable[i].BaseAddress == device) {
+                found = 1;
+                dev_id = i;
+                break;
+            }
+        }
+        if (!found) return -1;
     }
-#endif
-#ifdef XPAR_SPI_1_BASEADDR
-    if (device == XPAR_SPI_1_BASEADDR){
-        dev_id = 1;
-    }
-#endif
-
     status = XSpi_Initialize(&xspi[dev_id], dev_id);
     if (status != XST_SUCCESS) {
         return -1;

--- a/boards/sw_repo/pynqmb/src/spi.c
+++ b/boards/sw_repo/pynqmb/src/spi.c
@@ -104,9 +104,21 @@ spi spi_open_device(unsigned int device){
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_SPI0_BASEADDR
 #include "xio_switch.h"
+static int last_spiclk = -1;
+static int last_miso = -1;
+static int last_mosi = -1;
+static int last_ss = -1;
+
 spi spi_open(unsigned int spiclk, unsigned int miso, 
              unsigned int mosi, unsigned int ss){
-    init_io_switch();
+    if (last_spiclk != -1) set_pin(last_spiclk, GPIO);
+    if (last_miso != -1) set_pin(last_miso, GPIO);
+    if (last_mosi != -1) set_pin(last_mosi, GPIO);
+    if (last_ss != -1) set_pin(last_ss, GPIO);
+    last_spiclk = spiclk;
+    last_miso = miso;
+    last_mosi = mosi;
+    last_ss = ss;
     set_pin(spiclk, SPICLK0);
     set_pin(miso, MISO0);
     set_pin(mosi, MOSI0);

--- a/boards/sw_repo/pynqmb/src/spi.h
+++ b/boards/sw_repo/pynqmb/src/spi.h
@@ -54,13 +54,7 @@
 
 #include <xparameters.h>
 
-#ifdef XPAR_IO_SWITCH_NUM_INSTANCES
-#include "xio_switch.h"
-#endif
-
 #ifdef XPAR_XSPI_NUM_INSTANCES
-#include "xspi_l.h"
-#include "xspi.h"
 
 /*
  * SPI API

--- a/boards/sw_repo/pynqmb/src/timer.c
+++ b/boards/sw_repo/pynqmb/src/timer.c
@@ -53,6 +53,7 @@
 #include "timer.h"
 
 #ifdef XPAR_XTMRCTR_NUM_INSTANCES
+#include "xtmrctr.h"
 static XTmrCtr xtimer[XPAR_XTMRCTR_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 timer timer_open_device(unsigned int device) {
@@ -84,6 +85,7 @@ timer timer_open_device(unsigned int device) {
 
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_TIMER0_BASEADDR
+#include "xio_switch.h"
 timer timer_open(unsigned int pin){
     init_io_switch();
     set_pin(pin, TIMER_G0);

--- a/boards/sw_repo/pynqmb/src/timer.c
+++ b/boards/sw_repo/pynqmb/src/timer.c
@@ -88,8 +88,12 @@ timer timer_open_device(unsigned int device) {
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_TIMER0_BASEADDR
 #include "xio_switch.h"
+
+static int last_timer0 = -1;
+
 timer timer_open(unsigned int pin){
-    init_io_switch();
+    if (last_timer0 != -1) set_pin(last_timer0, GPIO);
+    last_timer0 = pin;
     set_pin(pin, TIMER_G0);
     return timer_open_device(XPAR_IO_SWITCH_0_TIMER0_BASEADDR);
 }

--- a/boards/sw_repo/pynqmb/src/timer.c
+++ b/boards/sw_repo/pynqmb/src/timer.c
@@ -55,23 +55,25 @@
 #ifdef XPAR_XTMRCTR_NUM_INSTANCES
 #include "xtmrctr.h"
 static XTmrCtr xtimer[XPAR_XTMRCTR_NUM_INSTANCES];
+extern XTmrCtr_Config XTmrCtr_ConfigTable[XPAR_XTMRCTR_NUM_INSTANCES];
+
 /************************** Function Definitions ***************************/
 timer timer_open_device(unsigned int device) {
     int status;
     u16 dev_id;
-
-    dev_id = (u16)device;
-#ifdef XPAR_TMRCTR_0_BASEADDR
-    if (device == XPAR_TMRCTR_0_BASEADDR){
-        dev_id = 0;
+    if (device < XPAR_XTMRCTR_NUM_INSTANCES) {
+        dev_id = (u16)device;
+    } else {
+        int found = 0;
+        for (u16 i = 0; i < XPAR_XTMRCTR_NUM_INSTANCES; ++i) {
+            if (XTmrCtr_ConfigTable[i].BaseAddress == device) {
+                found = 1;
+                dev_id = i;
+                break;
+            }
+        }
+        if (!found) return -1;
     }
-#endif
-#ifdef XPAR_TMRCTR_1_BASEADDR
-    if (device == XPAR_TMRCTR_1_BASEADDR){
-        dev_id = 1;
-    }
-#endif
-
     status = XTmrCtr_Initialize(&xtimer[dev_id], dev_id);
     if (status != XST_SUCCESS) {
         return -1;

--- a/boards/sw_repo/pynqmb/src/timer.h
+++ b/boards/sw_repo/pynqmb/src/timer.h
@@ -54,12 +54,7 @@
 
 #include <xparameters.h>
 
-#ifdef XPAR_IO_SWITCH_NUM_INSTANCES
-#include "xio_switch.h"
-#endif
-
 #ifdef XPAR_XTMRCTR_NUM_INSTANCES
-#include "xtmrctr.h"
 
 // TCSR0 Timer 0 Control and Status Register
 #define TCSR0 0x00

--- a/boards/sw_repo/pynqmb/src/uart.c
+++ b/boards/sw_repo/pynqmb/src/uart.c
@@ -52,6 +52,8 @@
 #include "uart.h"
 
 #ifdef XPAR_XUART_NUM_INSTANCES
+#include "xuartlite.h"
+#include "xuartlite_i.h"
 static XUartLite xuart[XPAR_XUART_NUM_INSTANCES];
 /************************** Function Definitions ***************************/
 uart uart_open_device(unsigned int device){
@@ -80,6 +82,7 @@ uart uart_open_device(unsigned int device){
 
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_UART0_BASEADDR
+#include "xio_switch.h"
 uart uart_open(unsigned int tx, unsigned int int rx){
     init_io_switch();
     set_pin(tx, UART0_TX);

--- a/boards/sw_repo/pynqmb/src/uart.c
+++ b/boards/sw_repo/pynqmb/src/uart.c
@@ -85,8 +85,14 @@ uart uart_open_device(unsigned int device){
 #ifdef XPAR_IO_SWITCH_NUM_INSTANCES
 #ifdef XPAR_IO_SWITCH_0_UART0_BASEADDR
 #include "xio_switch.h"
+static int last_tx = -1;
+static int last_rx = -1;
+
 uart uart_open(unsigned int tx, unsigned int int rx){
-    init_io_switch();
+    if (last_tx != -1) set_pin(last_tx, GPIO);
+    if (last_rx != -1) set_pin(last_rx, GPIO);
+    last_tx = tx;
+    last_rx = rx;
     set_pin(tx, UART0_TX);
     set_pin(rx, UART0_RX);
     return uart_open_device(XPAR_IO_SWITCH_0_UART0_BASEADDR);

--- a/boards/sw_repo/pynqmb/src/uart.c
+++ b/boards/sw_repo/pynqmb/src/uart.c
@@ -55,23 +55,25 @@
 #include "xuartlite.h"
 #include "xuartlite_i.h"
 static XUartLite xuart[XPAR_XUART_NUM_INSTANCES];
+extern XUartLite_Config XUartLite_ConfigTable[XPAR_XUART_NUM_INSTANCES];
+
 /************************** Function Definitions ***************************/
 uart uart_open_device(unsigned int device){
     int status;
     u16 dev_id;
-    
-    dev_id = (u16)device;
-#ifdef XPAR_UART_0_BASEADDR
-    if (device == XPAR_UART_0_BASEADDR){
-        dev_id = 0;
+    if (device < XPAR_XUART_NUM_INSTANCES) {
+        dev_id = (u16)device;
+    } else {
+        int found = 0;
+        for (u16 i = 0; i < XPAR_XUART_NUM_INSTANCES; ++i) {
+            if (XUartLite_ConfigTable[i].RegBaseAddr == device) {
+                found = 1;
+                dev_id = i;
+                break;
+            }
+        }
+        if (!found) return -1;
     }
-#endif
-#ifdef XPAR_UART_1_BASEADDR
-    if (device == XPAR_UART_1_BASEADDR){
-        dev_id = 1;
-    }
-#endif
-
     status = XUartLite_Initialize(&xuart[dev_id], dev_id);
     if (status != XST_SUCCESS) {
         return -1;

--- a/boards/sw_repo/pynqmb/src/uart.h
+++ b/boards/sw_repo/pynqmb/src/uart.h
@@ -53,13 +53,7 @@
 
 #include <xparameters.h>
 
-#ifdef XPAR_IO_SWITCH_NUM_INSTANCES
-#include "xio_switch.h"
-#endif
-
 #ifdef XPAR_XUART_NUM_INSTANCES
-#include "xuartlite.h"
-#include "xuartlite_i.h"
 
 /* 
  * UART API


### PR DESCRIPTION
I've done some modifications to the microblaze library based on what you PR'ed. Most of it is moving
as much as possible out of the header files - the reasoning is that those have to go through the
the Microblaze RPC flow and therefore being small is a benefit. I've also changed how you find base
addresses to use the config tables already included as part of the drivers which should scale to more
devices.

I feel we also need to avoid to resetting the IO switch every time it's used so that multiple devices can
be used simultaneously so I changed the code to unregister the old pins rather than reset the switch.
If you have other ideas I'd be more than happy to hear them as I accept this is a bit kludgey.